### PR TITLE
Add workflow to deploy to dev server on push to develop

### DIFF
--- a/.github/workflows/dev-server-deploy.yml
+++ b/.github/workflows/dev-server-deploy.yml
@@ -1,0 +1,32 @@
+name: Dev Server Deploy
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: yarn install
+    - name: Build
+      run: yarn build
+      
+    - name: Sync
+      env:
+        src: "build/"
+        dest: "iota-wiki/"
+      run: |
+        echo "${{ secrets.DEV_PRIVATE_KEY }}" > private_key
+        chmod 600 ./private_key
+        rsync -chav --delete \
+          -e 'ssh -i ./private_key -o StrictHostKeyChecking=no' \
+          "${{ env.src }}" "${{ secrets.DEV_USER }}@${{ secrets.DEV_HOST }}:/home/${{ secrets.DEV_USER }}/${{ env.dest }}"


### PR DESCRIPTION
We have set up a dev server with restricted access. This workflow will deploy the development branch to the dev server on every push, so the latest changes can be viewed by those who have access and are not able to checkout and build locally.

This workflow requires a few secrets to set up. I will do this once you agree on this approach.