### PR TITLE
Fix edit links until editor is live

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -210,7 +210,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/iota-community/iota-wiki',
+            'https://github.com/iota-community/iota-wiki/tree/develop/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
The docs edit link was pointing nowhere. I fixed this to point towards GitHub for now, until the editor is live.