### PR TITLE
Custom EditThisPage component that works with external docs.

### DIFF
--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -11,17 +11,17 @@ import IconEdit from '@theme/IconEdit';
 /**
 This function will remove "external/anyOtherString"
 **/
-function sanitizeExternalProjectURL(editUrl)
+function reformatExternalProjectURL(editUrl)
 {
     const externalDocsRegex =  new RegExp('external\/[^\/]*\/','i') ;
     return editUrl.replace(externalDocsRegex, '');
 }
 
 export default function EditThisPage({editUrl}) {
-  const sanitizedEditURL = sanitizeExternalProjectURL(editUrl);
+  const formattedEditURL = reformatExternalProjectURL(editUrl);
 
   return (
-    <a href={sanitizedEditURL} target="_blank" rel="noreferrer noopener">
+    <a href={formattedEditURL} target="_blank" rel="noreferrer noopener">
       <IconEdit />
       <Translate
         id="theme.common.editThisPage"

--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -8,6 +8,9 @@ import React from 'react';
 import Translate from '@docusaurus/Translate';
 import IconEdit from '@theme/IconEdit';
 
+/**
+This function will remove "external/anyOtherString"
+**/
 function sanitizeExternalProjectURL(editUrl)
 {
     const externalDocsRegex =  new RegExp('external\/[^\/]*\/','i') ;

--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import Translate from '@docusaurus/Translate';
+import IconEdit from '@theme/IconEdit';
+
+function sanitizeExternalProjectURL(editUrl)
+{
+    const externalDocsRegex =  new RegExp('external\/[^\/]*\/','i') ;
+    return editUrl.replace(externalDocsRegex, '');
+}
+
+export default function EditThisPage({editUrl}) {
+  const sanitizedEditURL = sanitizeExternalProjectURL(editUrl);
+
+  return (
+    <a href={sanitizedEditURL} target="_blank" rel="noreferrer noopener">
+      <IconEdit />
+      <Translate
+        id="theme.common.editThisPage"
+        description="The link label to edit the current page">
+        Edit this page
+      </Translate>
+    </a>
+  );
+}


### PR DESCRIPTION
# Description of change

Swizzled editThisPage component to replace /external/projectName/ with ''.  **You must set the edit url for each imported site for this to work properly.** Example: http://github.com/iotaledger/bee/tree/dev/


## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Enhancment

## How the change has been tested

Tested on local docusaurus site.  Please make sure to add a valid `editUrl` for each imported project, including the correct tree  the PR should target.  The tree is usually the default branch, but for some case like http://github.com/iotaledger/bee/ this is not the case.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested the wiki locally and tested that all external links work