### PR TITLE
Stylize tables

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,20 +4,42 @@ html {
   font-weight: 400;
 }
 
-article {  
-  max-width: 800px; 
-  padding-top: 3rem; 
+article {
+  max-width: 800px;
+  padding-top: 3rem;
   padding-bottom: 3rem;
 }
 
-h1 {    
-  font-size: 2.5rem !important;  
-}  
+h1 {
+  font-size: 2.5rem !important;
+}
 
-h2 {    
- font-size: 1.8rem !important; 
- padding-top: 1rem; 
-} 
+h2 {
+ font-size: 1.8rem !important;
+ padding-top: 1rem;
+}
+
+table *,
+table th,
+table td,
+table thead tr,
+table tr:nth-child(n) {
+  border: none;
+  background-color: transparent;
+}
+
+table th, table td {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+table tbody {
+  vertical-align: top;
+}
+
+table tr:nth-child(n):not(table tr:first-child) {
+  border-top: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
+}
 
 
   @font-face {
@@ -421,7 +443,7 @@ h2 {
 
   html[data-theme='dark'] {
     --ifm-color-primary: #14CABF;
-    
+
     --ifm-background-color: #0D192F;
     --ifm-background-surface-color: #0D192F;
 


### PR DESCRIPTION
I just did a CSS reset on the border and background in tables and only did a top border in the table body rows, however somehow this still renders every second border a bit thicker than the others and I have no idea why. I think this PR is a step in the right direction and I'm ok with merging it, but somebody more knowledgeable in CSS should probably have a look at it at some point to get it right.