### PR TITLE
Fix styles after mega menu merging 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -261,7 +261,7 @@ h2 {
 
   --ifm-background-color: var(--ifm-color-gray-000);
 
-  --ifm-background-color: #f6f8fc;
+  --ifm-background-color: white;
 
   --ifm-hover-overlay: var(--ifm-color-emphasis-200);
 
@@ -283,6 +283,7 @@ h2 {
   --ifm-navbar-link-hover-color: var(--ifm-color-primary);
   --ifm-navbar-link-active-color: var(--ifm-color-primary);
 
+  --ifm-dropdown-hover-background-color: rgba(72, 87, 118, 0.08);
 
   --ifm-footer-color: var(--ifm-color-gray-300);
   --ifm-footer-title-color: var(--ifm-color-gray-700);
@@ -505,48 +506,4 @@ Logo fonts CSS
     font-weight: normal;
     font-style: normal;
     font-display: block;
-}
-
-.link__icon {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'icomoon' !important;
-
-  /* Better Font Rendering =========== */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
-  width: 2rem;
-  height: 2rem;
-}
-
-[data-theme='dark'] .link__icon {
-  color:var(--ifm-navbar-link-color);
-  background-color: #313E58;
-}
-
-.mega-dropdown__label {
-  text-transform: uppercase;
-  letter-spacing: 1px;
-}
-
-.link__sublabel {
-  font-family: inter;
-}
-
-/*
-Active Link in mega menu
-*/
-.dropdown__link--active .link__icon {
-  color: white;
-  background-color: var(--ifm-color-primary);
-}
-
-.dropdown__link--active, .dropdown__link--active:hover {
-  color: var(--ifm-color-gray-800);
-  background-color: #EDFBFA;
-}
-
-[data-theme='dark'] .dropdown__link--active, [data-theme='dark'] .dropdown__link--active:hover {
-  color:white;
-  background-color: #1A2334;
 }

--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -24,6 +24,8 @@
   max-height: calc(100vh - var(--ifm-navbar-height) - var(--docusaurus-announcement-bar-height));
   overflow-y: auto;
   padding: var(--ifm-navbar-padding-vertical) var(--ifm-navbar-padding-horizontal);
+  border-top: 1px solid var(--ifm-color-gray-300);
+  border-bottom: 1px solid var(--ifm-color-gray-300);
 }
 
 .mega-dropdown__label {
@@ -31,11 +33,13 @@
   align-items: flex-end;
   border-radius: 0.25rem;
   color: var(--ifm-menu-color);
-  font-family: var(--ifm-heading-font-family);
+  font-family: Metropolis Bold;
   font-size: 0.875rem;
   height: 100%;
   padding: 0.25rem 0.5rem;
   white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 .link {
@@ -49,13 +53,54 @@
   align-items: center;
   font-size: 1.5rem;
   margin-right: 10px;
-  background-color: var(--ifm-color-secondary);
+  background-color: var(--ifm-color-gray-200);
   border-radius: var(--ifm-global-radius);
   color: var(--ifm-dropdown-link-color);
+
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'icomoon' !important;
+  
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  
+  width: 2rem;
+  height: 2rem;
+}
+
+[data-theme='dark'] .link__icon {
+  color:var(--ifm-navbar-link-color);
+  background-color: #313E58;
 }
 
 .link__sublabel {
   color: var(--ifm-menu-color);
   font-weight: 400;
   font-size: 80%;
+  font-family: inter;
 }
+
+/*
+Active Link in mega menu
+*/
+[data-theme='dark'] .mega-dropdown__menu {
+  border-color: #1A2334;
+}
+
+.dropdown__link--active .link__icon {
+  color: white;
+  background-color: #14CABF;
+}
+
+.dropdown__link--active, .dropdown__link--active:hover {
+  color: var(--ifm-color-gray-800);
+  background-color: #EDFBFA;
+}
+
+[data-theme='dark'] .dropdown__link--active, [data-theme='dark'] .dropdown__link--active:hover {
+  color:white;
+  background-color: var(--ifm-dropdown-hover-background-color)
+}
+/*
+END Active Link in mega menu
+*/

--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -34,12 +34,16 @@
   border-radius: 0.25rem;
   color: var(--ifm-menu-color);
   font-family: Metropolis Bold;
-  font-size: 0.875rem;
+  font-size: 0.825rem;
   height: 100%;
-  padding: 0.25rem 0.5rem;
+  padding: 1.5rem 0.25rem 0.8rem 0.5rem;
   white-space: nowrap;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+.dropdown__link {
+  margin:0.2rem 0
 }
 
 .link {
@@ -51,7 +55,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 1.5rem;
+  font-size: 1.7rem;
   margin-right: 10px;
   background-color: var(--ifm-color-gray-200);
   border-radius: var(--ifm-global-radius);
@@ -64,8 +68,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   
-  width: 2rem;
-  height: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
 }
 
 [data-theme='dark'] .link__icon {
@@ -73,10 +77,16 @@
   background-color: #313E58;
 }
 
+.link__label {
+  font-family: Metropolis Semi Bold;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
 .link__sublabel {
   color: var(--ifm-menu-color);
   font-weight: 400;
-  font-size: 80%;
+  font-size: 85%;
   font-family: inter;
 }
 
@@ -85,6 +95,10 @@ Active Link in mega menu
 */
 [data-theme='dark'] .mega-dropdown__menu {
   border-color: #1A2334;
+}
+
+[data-theme='dark'] .mega-dropdown__label {
+  color: var(--ifm-color-gray-600);
 }
 
 .dropdown__link--active .link__icon {


### PR DESCRIPTION
# Description of change

Fixed CSS (dark and light mode) after merging mega menu. Moved the relevant CSS from custom.css to /theme/NavbarItem/styles.css. 

![Screenshot_9](https://user-images.githubusercontent.com/53269239/132110921-47a7f3df-178b-40ee-a9cb-e1f3596422a4.jpg)
![Screenshot_10](https://user-images.githubusercontent.com/53269239/132110922-e9d1225f-4e4d-4e74-8578-327ef6b3deff.jpg)


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally

