### PR TITLE
Remove blog post reading time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -326,7 +326,7 @@ module.exports = {
           remarkPlugins: [require('remark-code-import'), require('remark-import-partial')],
         },
         blog: {
-          showReadingTime: true,
+          showReadingTime: false,
           blogSidebarCount: 0,
         },
         theme: {


### PR DESCRIPTION
# Description of change

This PR removes the blog post reading time. As mentioned in #188 posts are always automatically labelled with misleading "One min read" because we are using excerpts. 

## Links to any relevant issues

fixes issue #188 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
