### PR TITLE
Fix card image gap

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,12 +35,12 @@
 }
 
 .card__image {
-  background: linear-gradient(180deg, #001c56 0%, #074db6 100%);
+  background: linear-gradient(180deg, #001c56, #074db6);
 }
 
 .card__image img {
+  display: block;
   width: 100%;
-  margin-bottom: -8px;
 }
 
 .footer__copyright {


### PR DESCRIPTION
The gap below the Learn image is caused by images being inline elements by default and thus leave space for descenders below the baseline. I changed the image elements in the cards to be block elements as per [this answer on Stack Overflow](https://stackoverflow.com/a/5804278) to fix this properly.