### PR TITLE
Change blog post linking

### DIFF
--- a/blog/2018-08-15_manufacturing_economy.md
+++ b/blog/2018-08-15_manufacturing_economy.md
@@ -3,6 +3,7 @@ slug: manufacturing-economy
 title: "Manufacturing Economy"
 authors: dtrauth
 tags: [Community, IoT, IOTA LAB AACHEN]
+url: https://medium.com/industrial-iota-lab-aachen-wzl-of-rwth-aachen/manufacturing-economy-e541066889ee
 ---
 
 ![IOTA Lab Aachen](https://miro.medium.com/max/7500/1*2itDXVMO-8iOZF44ttIR6g.png)

--- a/blog/2019-03-02_finite_element_method_as_a_service.md
+++ b/blog/2019-03-02_finite_element_method_as_a_service.md
@@ -2,6 +2,7 @@
 title: "IILA x IOTA — Finite Element Method As A Service"
 authors: dtrauth
 tags: [Community, IoT, IOTA LAB AACHEN]
+url: https://medium.com/industrial-iota-lab-aachen-wzl-of-rwth-aachen/iila-x-iota-finite-element-method-as-a-service-2a782a479516
 ---
 
 ![IOTA Lab Aachen](https://miro.medium.com/max/7500/1*hSwB4GL_DqsPck5Dtg9o-A.png)

--- a/blog/2021-01-19_the_economic_model_of_iota.md
+++ b/blog/2021-01-19_the_economic_model_of_iota.md
@@ -3,6 +3,7 @@ slug: the-economic-model
 title: "The Economic Model of IOTA"
 authors: lstanisic
 tags: [Community, Economic, Mana]
+url: https://luka99.medium.com/the-economic-model-of-iota-c28732143d51
 ---
 
 ![IOTA](https://miro.medium.com/max/776/1*4lxkm50oJ02YOPo8MLgnKQ.png)

--- a/blog/2021-01-20_The_tech_behind_IOTA_1.md
+++ b/blog/2021-01-20_The_tech_behind_IOTA_1.md
@@ -3,6 +3,7 @@ slug: the-tech-behind-IOTA-1
 title: "The Tech Behind IOTA — Part 1 (Introduction)"
 authors: lstanisic
 tags: [Community, Coordicide, Mana]
+url: https://luka99.medium.com/the-tech-behind-iota-part-1-introduction-b8f82775325a
 ---
 
 ![Tangle](https://miro.medium.com/max/1400/1*p2lxgHwQd4yr_cje9NOwSg.jpeg)

--- a/blog/2021-01-23_why_IOTA.md
+++ b/blog/2021-01-23_why_IOTA.md
@@ -3,6 +3,7 @@ slug: why-iota
 title: "Why IOTA?"
 authors: lstanisic
 tags: [Community, Ethereum, Bitcoin]
+url: https://luka99.medium.com/why-iota-4f563c375afb
 ---
 
 ![IOTA](https://miro.medium.com/max/1400/1*WWI0yj4CW3ynmBS168N8vg.png)

--- a/blog/2021-01-31_The_tech_behind_IOTA_2.md
+++ b/blog/2021-01-31_The_tech_behind_IOTA_2.md
@@ -3,6 +3,7 @@ slug: the-tech-behind-IOTA-2
 title: "The Tech Behind IOTA — Part 2 (Consensus)"
 authors: lstanisic
 tags: [Community, Coordicide, Mana]
+url: https://luka99.medium.com/the-tech-behind-iota-part-2-consensus-88c74917b993
 ---
 
 ![Coordicide](https://miro.medium.com/max/1400/1*9DcgQ-EnPojAQADRUsi8Rg.png)

--- a/blog/2021-05-11_the_chirping_machine.md
+++ b/blog/2021-05-11_the_chirping_machine.md
@@ -3,6 +3,7 @@ slug: the-chirping-machine
 title: "The Chirping Machine"
 authors: borg
 tags: [Community, Distributed Ledger, Gossip]
+url: https://medium.com/coinmonks/the-chirping-machine-4c73269c2871
 ---
 
 ![Die Zwitscher-Maschine](https://miro.medium.com/max/1400/0*-ldlm3IWjU4FOEBU.jpg)

--- a/blog/2021-06-16_My-take-on-IOTAs-community-treasury.md
+++ b/blog/2021-06-16_My-take-on-IOTAs-community-treasury.md
@@ -3,6 +3,7 @@ slug: my-take-community-treasury
 title: "My take on IOTA’s Community Treasury"
 authors: lstanisic
 tags: [Community, DAO, Commmunity Treasury]
+url: https://luka99.medium.com/my-take-on-iotas-community-treasury-f40deb7b56ba
 ---
 
 ![Treasuries](https://miro.medium.com/max/1400/1*Ydf9L3h3ZOKJ2NbHWmPIdw.png)

--- a/blog/2021-08-06_layer_one_1.md
+++ b/blog/2021-08-06_layer_one_1.md
@@ -3,6 +3,7 @@ slug: layer_one_1
 title: "Layer One—Part 1: Assimilation"
 authors: kbrennan
 tags: [Community, Layer One]
+url: https://iologica.substack.com/p/assimilation
 ---
 
 ![Assimilation](https://cdn.substack.com/image/fetch/w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F902fa1ea-6e2e-44aa-82b3-1bf4d2d7ef37_1920x1080.jpeg)

--- a/blog/2021-08-06_layer_one_2.md
+++ b/blog/2021-08-06_layer_one_2.md
@@ -3,6 +3,7 @@ slug: layer_one_2
 title: "Layer One—Part 2: Error Correction"
 authors: kbrennan
 tags: [Community, Layer One]
+url: https://iologica.substack.com/p/error-correction
 ---
 
 ![Error Correction](https://cdn.substack.com/image/fetch/w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F21ced77a-e1b6-4315-80c4-15f2e9223402_510x570.jpeg)

--- a/blog/2021-08-06_layer_one_3.md
+++ b/blog/2021-08-06_layer_one_3.md
@@ -3,6 +3,7 @@ slug: layer_one_3
 title: "Layer One—Part 3: Metamoney"
 authors: kbrennan
 tags: [Community, Layer One]
+url: https://iologica.substack.com/p/metamoney
 ---
 
 ![Parallel Reality](https://cdn.substack.com/image/fetch/w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2Fa8b72adf-7a43-4c69-98c9-01fd061c302d_6915x3889.jpeg)

--- a/blog/2021-08-11_unpopular_opinion.md
+++ b/blog/2021-08-11_unpopular_opinion.md
@@ -3,6 +3,7 @@ slug: bitcoin-middle-man
 title: "Unpopular opinion: Bitcoin did not get rid of the middle-man"
 authors: lnaumann
 tags: [Community, Bitcoin]
+url: https://medium.com/@linus.naumann/unpopular-opinion-bitcoin-did-not-get-rid-of-the-middle-man-71aced8c5e3f
 ---
 
 ![miners](https://miro.medium.com/max/1400/1*Tacwi1EDsoRkqR7b_weUBg.png)

--- a/blog/2021-08-14_A_future_day_with_IOTA_1.md
+++ b/blog/2021-08-14_A_future_day_with_IOTA_1.md
@@ -3,6 +3,7 @@ slug: future_day_1
 title: A future day with IOTA — Part I
 authors: lnaumann
 tags: [Community]
+url: https://medium.com/@linus.naumann/a-future-day-with-iota-part-i-239c16a011f3
 ---
 
 ![morning](https://miro.medium.com/max/1400/1*QBPB-rYtEpp37SPnWJ3QvA.jpeg)

--- a/blog/2021-08-18_Parallel_realities_and_IOTAs_breakthrough_Multiverse_consensus.md
+++ b/blog/2021-08-18_Parallel_realities_and_IOTAs_breakthrough_Multiverse_consensus.md
@@ -3,6 +3,7 @@ slug: multiverse_consensus
 title: Parallel realities and IOTAs breakthrough “Multiverse consensus”
 authors: lnaumann
 tags: [Community, OTV, Multiverse]
+url: https://medium.com/@linus.naumann/parallel-realities-and-iotas-multiverse-consensus-bcfbf3b12aad
 ---
 
 ![conflics](https://miro.medium.com/max/1400/1*uaihe82n_l6vkHMz-gMl4A.gif)

--- a/blog/2021-08-22_A_future_day_with_IOTA_2.md
+++ b/blog/2021-08-22_A_future_day_with_IOTA_2.md
@@ -3,6 +3,7 @@ slug: future_day_2
 title: A future day with IOTA — Part II
 authors: lnaumann
 tags: [Community]
+url: https://medium.com/@linus.naumann/a-future-day-with-iota-part-ii-revelations-c3926202f3c4
 ---
 
 ![keyboard](https://miro.medium.com/max/1400/1*b3PJxjzbZXmuCr8bhK-Jyw.png)

--- a/blog/2021-09-16_Exploring_ISCP_in_a_private_network_Developing_A_Prediction_Market.md
+++ b/blog/2021-09-16_Exploring_ISCP_in_a_private_network_Developing_A_Prediction_Market.md
@@ -3,6 +3,7 @@ slug: develop_prediction_market
 title: ISCP in a Private Network - Developing a Prediction Market
 authors: aklein
 tags: [Community, ISCP]
+url: https://medium.com/51nodes/exploring-iota-2-0-smart-contracts-in-a-private-network-developing-a-prediction-market-c2d81988f75e
 ---
 
 ![keyboard](https://miro.medium.com/max/700/1*wkujYx46q_Wb4V-Rj7iMRA.png)

--- a/blog/2021-09-24_My_opinion_on_iscp_security_improvement_proposal.md
+++ b/blog/2021-09-24_My_opinion_on_iscp_security_improvement_proposal.md
@@ -3,6 +3,7 @@ slug: iscp_security_proposal
 title: My opinion on ISCP — security improvement proposal
 authors: lstanisic
 tags: [Community, ISCP]
+url: https://luka99.medium.com/my-opinion-on-iota-smart-contract-protocol-iscp-security-improvement-proposal-c6ca3ca3df23
 ---
 
 ![keyboard](https://miro.medium.com/max/1400/1*mUjOq0Y8iBfLC-4ztXEiTg.jpeg)

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -118,7 +118,7 @@ function BlogPostItem(props) {
         />
       )}
 
-      <div className='blogPost__body' itemProp='articleBody'>
+      <div className={clsx('markdown', [styles.blogPost__body])} itemProp='articleBody'>
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </div>
 

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -50,16 +50,8 @@ function BlogPostItem(props) {
     truncated,
     isBlogPostPage = false,
   } = props;
-  const {
-    date,
-    formattedDate,
-    permalink,
-    tags,
-    readingTime,
-    title,
-    editUrl,
-    authors,
-  } = metadata;
+  const { date, formattedDate, tags, readingTime, title, editUrl, authors } =
+    metadata;
   const image = assets.image ?? frontMatter.image;
   const url = frontMatter.url;
 
@@ -118,7 +110,10 @@ function BlogPostItem(props) {
         />
       )}
 
-      <div className={clsx('markdown', [styles.blogPost__body])} itemProp='articleBody'>
+      <div
+        className={clsx('markdown', [styles.blogPost__body])}
+        itemProp='articleBody'
+      >
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </div>
 

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -61,6 +61,7 @@ function BlogPostItem(props) {
     authors,
   } = metadata;
   const image = assets.image ?? frontMatter.image;
+  const url = frontMatter.url;
 
   const renderPostHeader = () => {
     const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
@@ -71,7 +72,7 @@ function BlogPostItem(props) {
           {isBlogPostPage ? (
             title
           ) : (
-            <Link itemProp='url' to={permalink}>
+            <Link itemProp='url' to={url}>
               {title}
             </Link>
           )}
@@ -117,7 +118,7 @@ function BlogPostItem(props) {
         />
       )}
 
-      <div className='markdown' itemProp='articleBody'>
+      <div className='blogPost__body' itemProp='articleBody'>
         <MDXProvider components={MDXComponents}>{children}</MDXProvider>
       </div>
 

--- a/src/theme/BlogPostItem/styles.module.css
+++ b/src/theme/BlogPostItem/styles.module.css
@@ -13,6 +13,10 @@
   font-size: 3rem;
 }
 
+.blogPost__body {
+  margin: 0;
+}
+
 .blogPostData {
   font-size: 0.9rem;
   position: relative;

--- a/src/theme/BlogPostItem/styles.module.css
+++ b/src/theme/BlogPostItem/styles.module.css
@@ -32,4 +32,3 @@
   margin-left: auto;
   margin-bottom: 2px;
 }
-

--- a/src/theme/BlogPostItem/styles.module.css
+++ b/src/theme/BlogPostItem/styles.module.css
@@ -6,10 +6,10 @@
  */
 
 .blogHeader a:hover {
-  border:none
+  text-decoration: none;
 }
 
- .blogPostTitle {
+.blogPostTitle {
   font-size: 3rem;
 }
 
@@ -29,7 +29,3 @@
   margin-bottom: 2px;
 }
 
-.tagsList a:hover {
-  border: 1px solid var(--docusaurus-tag-list-border);
-  padding: .3rem .5rem;
-}


### PR DESCRIPTION
# Description of change

This PR changes the linking of the **blog post headlines** directly to the source (medium.com, etc.). So far, they were linked to a page with the same excerpt as on the overview, which was misleading.

+ little styling fix 

## How the change has been tested

Tested locally