### PR TITLE
SEO - Avoid layout shift (CLS)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,11 +47,8 @@ article .card {
 
 .card__image {
   background: linear-gradient(180deg, #001c56, #074db6);
-}
-
-.card__image img {
-  display: block;
   width: 100%;
+  height: auto;
 }
 
 .card__header {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,9 +21,13 @@ function Card({ title, image, link, description }) {
         onClick={handleClick}
       >
         {image && (
-          <div className='card__image'>
-            <img alt={title} src={useBaseUrl(image)} />
-          </div>
+          <img
+            alt={title}
+            className='card__image'
+            src={useBaseUrl(image)}
+            width='337'
+            height='342'
+          />
         )}
         <div className='card__body padding-horiz--lg padding-bottom--lg'>
           {title && <h3>{title}</h3>}


### PR DESCRIPTION
# Description of change

This PR adds width and height to our card images (robots). This is necessary to avoid layout shift on page load.
CLS (Cumulative Layout Shift) is also a Google SEO metric nowadays.
See here: https://web.dev/optimize-cls/

Loading old

![Screenshot_1](https://user-images.githubusercontent.com/53269239/139579490-42deb8b9-f5c4-482c-bac0-9d41cae51957.jpg)

Loading new

![Screenshot_3](https://user-images.githubusercontent.com/53269239/139579518-c9041b41-689a-45ad-bcd8-f605b6604fcd.jpg)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally

