### PR TITLE
Add some Shimmmer to the wiki

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
     announcementBar: {
       id: 'shimmer',
       content:
-        'Interested in the upcoming incentivized staging network and staking IOTA tokens? Read more about it <a target="_blank" href="https://shimmer.network">here</a>.',
+        'Interested in the upcoming incentivized staging network Shimmer, and in staking your IOTA tokens? Read more about it <a target="_blank" href="https://shimmer.network">here</a>.',
       backgroundColor: '#00e0ca',
       textColor: '#000000',
       isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,14 @@ module.exports = {
     },
   ],
   themeConfig: {
+    announcementBar: {
+      id: 'shimmer',
+      content:
+        'Interested in the new incentivized staging network and staking IOTAs? Read more about it <a target="_blank" href="https://shimmer.network">here</a>',
+      backgroundColor: '#00e0ca',
+      textColor: '#000000',
+      isCloseable: true,
+    },
     image: 'img/iota-wiki.png',
     algolia: {
       apiKey: '829457a9c9dd5a8ddd31d08c86e154c2',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
     announcementBar: {
       id: 'shimmer',
       content:
-        'Interested in the new upcoming incentivized staging network and staking IOTAs? Read more about it <a target="_blank" href="https://shimmer.network">here</a>',
+        'Interested in the upcoming incentivized staging network and staking IOTA tokens? Read more about it <a target="_blank" href="https://shimmer.network">here</a>.',
       backgroundColor: '#00e0ca',
       textColor: '#000000',
       isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
     announcementBar: {
       id: 'shimmer',
       content:
-        'Interested in the new incentivized staging network and staking IOTAs? Read more about it <a target="_blank" href="https://shimmer.network">here</a>',
+        'Interested in the new upcoming incentivized staging network and staking IOTAs? Read more about it <a target="_blank" href="https://shimmer.network">here</a>',
       backgroundColor: '#00e0ca',
       textColor: '#000000',
       isCloseable: true,


### PR DESCRIPTION
# Description of change

Added an announcement bar for Shimmer.
<img width="1774" alt="wiki_announcement_bar" src="https://user-images.githubusercontent.com/61637085/142064526-06aec651-32b2-48c5-a571-6e7eef2d0025.png">

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
