### PR TITLE
Fixing links to external Bee and Hornet entrypoints

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,7 +117,7 @@ module.exports = {
                 {
                   label: 'Bee Node',
                   sublabel: 'IOTA node written in Rust',
-                  to: 'bee/getting_started/getting_started',
+                  to: 'bee/getting_started',
                   icon: '\ue900',
                   activeBaseRegex: 'bee/.*',
                 },

--- a/internal/participate/support-the-network/node-software.md
+++ b/internal/participate/support-the-network/node-software.md
@@ -31,7 +31,7 @@ The source code of the software can be found here:
 
 Standard installation following the Hornet Documentation:
 
-- [Hornet documentation - set up a node](/hornet/getting_started/getting_started)
+- [Hornet documentation - set up a node](/hornet/getting_started)
 
 ### Hornet Community Tutorials:
 
@@ -64,7 +64,7 @@ Bee will also be further developed to be a reference implementation in the upcom
 
 The full documentation for BEE can be found here:
 
-- [BEE Documentation](/bee/getting_started/getting_started)
+- [BEE Documentation](/bee/getting_started)
 
 The source code of the software can be found here:
 


### PR DESCRIPTION
# Description of change

Links for Hornet and Bee documentation is redirecting to 404

## Links to any relevant issues

NA

## Type of change
- Documentation Fix

## How the change has been tested

Tested the links in local

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
