### PR TITLE
Move "role of IOTA" to its own page

### DIFF
--- a/internal/learn/future/assembly.md
+++ b/internal/learn/future/assembly.md
@@ -13,14 +13,4 @@ keywords:
 In December 2021, IOTA Foundation [introduced](https://blog.assembly.sc/announcing-assembly-and-the-asmb-token/) Assembly, a permissionless Smart Contracts network. Assembly will function as an intermediate layer for permissionless and interoperable Smart Contracts, and will have its own token called [ASMB](https://assembly.sc/token).
 For more information, check the official [Website](https://assembly.sc) or the [Assembly Wiki](https://wiki.assembly.sc).
 
-## The role of the IOTA Token
-
-Assembly is build on top of the Tangle, it will need the Tangle for anchored state updates, interoperability between chains, for Native Assets and general access to a congested network. There are two main usages of the IOTA Token in Assembly.
-
-### The new dust protection
-
-With the new [dust protection](https://github.com/iotaledger/tips/pull/39), all data stored on the Tangle needs to be backed by IOTA Tokens. For example, every NFT, SC chain state anchor or Native Asset requires a deposit of IOTA Tokens in order to be stored on L1. You can read more about the new dust protection in this [community blog post](https://medium.com/@wernerderchamp/dust-protection-on-the-iota-network-an-eli12-d8ca567a2d36).
-
-### Mana
-
-Assembly nodes have to anchor the chain state often, even if the Tangle is congested. To get a fair share of the Tangle throughput in the [next version](https://v2.iota.org) of the IOTA protocol, you will need [Mana](/IOTA-2.0-Research-Specifications/5.3Mana), and Mana is derived directly from the IOTA Token. Assembly nodes will have to hold IOTA tokens, which will increase demand even more.
+There is also an article about the [role of IOTA](./role-of-iota) which is really important for a better understanding why IOTA needs the IOTA token.

--- a/internal/learn/future/assembly.md
+++ b/internal/learn/future/assembly.md
@@ -13,4 +13,3 @@ keywords:
 In December 2021, IOTA Foundation [introduced](https://blog.assembly.sc/announcing-assembly-and-the-asmb-token/) Assembly, a permissionless Smart Contracts network. Assembly will function as an intermediate layer for permissionless and interoperable Smart Contracts, and will have its own token called [ASMB](https://assembly.sc/token).
 For more information, check the official [Website](https://assembly.sc) or the [Assembly Wiki](https://wiki.assembly.sc).
 
-There is also an article about the [role of IOTA](./role-of-iota) which is really important for a better understanding why IOTA needs the IOTA token.

--- a/internal/learn/future/role-of-the-iota-token.md
+++ b/internal/learn/future/role-of-the-iota-token.md
@@ -8,12 +8,12 @@ keywords:
   - ASMB
 ---
 
-With the introduction of [Assemly](./assembly) it's important to understand the role of the IOTA token. Assembly is build on top of the Tangle, it will need the Tangle for anchored state updates, interoperability between chains, for Native Assets and general access to a congested network. There are two main usages of the IOTA Token in Assembly and everyting build on top of IOTA.
+With the introduction of [Assemly](./assembly) it's important to understand the role of the IOTA token. Assembly is build on top of the Tangle, it will need the Tangle for anchored state updates, interoperability between chains, for Native Assets and general access to a congested network. There are two main usages of the IOTA token in Assembly and everyting build on top of IOTA.
 
 ## The new dust protection
 
-With the new [dust protection](https://github.com/iotaledger/tips/pull/39), all data stored on the Tangle needs to be backed by IOTA Tokens. For example, every NFT, SC chain state anchor or Native Asset requires a deposit of IOTA Tokens in order to be stored on L1. You can read more about the new dust protection in this [community blog post](https://medium.com/@wernerderchamp/dust-protection-on-the-iota-network-an-eli12-d8ca567a2d36) or in [this](./dust-protection#new-tokenisation-framework) wiki articel about the history of the dust protection in IOTA.
+With the new [dust protection](https://github.com/iotaledger/tips/pull/39), all data stored on the Tangle needs to be backed by IOTA tokens. For example, every NFT, SC chain state anchor or Native Asset requires a deposit of IOTA tokens in order to be stored on L1. You can read more about the new dust protection in this [community blog post](https://medium.com/@wernerderchamp/dust-protection-on-the-iota-network-an-eli12-d8ca567a2d36) or in [this Wiki article](./dust-protection#new-tokenisation-framework) about the history of the dust protection in IOTA.
 
 ## Mana
 
-Assembly nodes have to anchor the chain state often, even if the Tangle is congested. To get a fair share of the Tangle throughput in the [next version](https://v2.iota.org) of the IOTA protocol, you will need [Mana](/IOTA-2.0-Research-Specifications/5.3Mana), and Mana is derived directly from the IOTA Token. Assembly nodes will have to hold IOTA tokens, which will increase demand even more.
+Assembly nodes have to anchor the chain state often, even if the Tangle is congested. To get a fair share of the Tangle throughput in the [next version](https://v2.iota.org) of the IOTA protocol, you will need [Mana](/IOTA-2.0-Research-Specifications/5.3Mana), and Mana is derived directly from the IOTA token. Assembly nodes will have to hold IOTA tokens, which will increase demand even more.

--- a/internal/learn/future/role-of-the-iota-token.md
+++ b/internal/learn/future/role-of-the-iota-token.md
@@ -1,0 +1,19 @@
+---
+id: role-of-iota
+title: Role of the IOTA Token
+description: Introduction to the emerging permissionless Smart Contracts network
+keywords:
+  - smart contracts
+  - permissionless
+  - ASMB
+---
+
+With the introduction of [Assemly](./assembly) it's important to understand the role of the IOTA token. Assembly is build on top of the Tangle, it will need the Tangle for anchored state updates, interoperability between chains, for Native Assets and general access to a congested network. There are two main usages of the IOTA Token in Assembly and everyting build on top of IOTA.
+
+## The new dust protection
+
+With the new [dust protection](https://github.com/iotaledger/tips/pull/39), all data stored on the Tangle needs to be backed by IOTA Tokens. For example, every NFT, SC chain state anchor or Native Asset requires a deposit of IOTA Tokens in order to be stored on L1. You can read more about the new dust protection in this [community blog post](https://medium.com/@wernerderchamp/dust-protection-on-the-iota-network-an-eli12-d8ca567a2d36) or in [this](./dust-protection#new-tokenisation-framework) wiki articel about the history of the dust protection in IOTA.
+
+## Mana
+
+Assembly nodes have to anchor the chain state often, even if the Tangle is congested. To get a fair share of the Tangle throughput in the [next version](https://v2.iota.org) of the IOTA protocol, you will need [Mana](/IOTA-2.0-Research-Specifications/5.3Mana), and Mana is derived directly from the IOTA Token. Assembly nodes will have to hold IOTA tokens, which will increase demand even more.

--- a/internal/learn/sidebars.js
+++ b/internal/learn/sidebars.js
@@ -86,6 +86,7 @@ module.exports = {
         },
         'future/shimmer',
         'future/assembly',
+        'future/role-of-iota',
         'future/dust-protection',
       ],
     },


### PR DESCRIPTION
# Description of change

I moved the `role of IOTA` to its own page. This topic will just get more important over time and I think it deserves its own
section :)

## Type of change

- Documentation Fix
