### PR TITLE
Docs - Integration Services - Use master branch 

### DIFF
--- a/config.json
+++ b/config.json
@@ -60,7 +60,6 @@
     },
     {
       "repo": "https://github.com/iotaledger/integration-services",
-      "checkoutParams": ["--branch develop"],
       "staticPath": "./documentation/static"
     }
   ]


### PR DESCRIPTION
# Description of change

Removed `develop` branch specification for integration services to use the default `master` branch

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Enhancement

## How the change has been tested

Wiki was built locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have tested the wiki locally and tested that all external links work
