### PR TITLE
Change Blog to Community Blog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -231,7 +231,7 @@ module.exports = {
             },
           ],
         },
-        { to: '/blog', label: 'Blog', position: 'right' },
+        { to: '/blog', label: 'Community Blog', position: 'right' },
         { to: '/team', label: 'Team', position: 'right' },
       ],
     },


### PR DESCRIPTION
# Description of change

Change name of `Blog` to `Community Blog` to don't create confusion.

## Links to any relevant issues

fixes issue #298 

## Type of change

- Documentation Enhancement

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested the wiki locally and tested that all external links work
