### PR TITLE
Fix content carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@jlvandenhout/docusaurus-plugin-docs-editor": "^0.7.0",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
-    "axios": "^0.25.0",
     "clsx": "^1.1.1",
     "docusaurus-plugin-hotjar": "^0.0.2",
     "docusaurus-plugin-matomo": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7786,6 +7786,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.14.7":
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
+  languageName: node
+  linkType: hard
+
 "for-in@npm:^1.0.2":
   version: 1.0.2
   resolution: "for-in@npm:1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7786,16 +7786,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.7":
-  version: 1.14.8
-  resolution: "follow-redirects@npm:1.14.8"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 40c67899c2e3149a27e8b6498a338ff27f39fe138fde8d7f0756cb44b073ba0bfec3d52af28f20c5bdd67263d564d0d8d7b5efefd431de95c18c42f7b4aef457
-  languageName: node
-  linkType: hard
-
 "for-in@npm:^1.0.2":
   version: 1.0.2
   resolution: "for-in@npm:1.0.2"
@@ -9133,7 +9123,6 @@ __metadata:
     "@types/webpack-env": ^1.16.3
     "@typescript-eslint/eslint-plugin": ^5.9.1
     "@typescript-eslint/parser": ^5.9.1
-    axios: ^0.25.0
     clsx: ^1.1.1
     docusaurus-plugin-hotjar: ^0.0.2
     docusaurus-plugin-matomo: ^0.0.3


### PR DESCRIPTION
# Description of change

The content resolve logic relied on directory listing, which is not supported on GitHub pages. I reverted the logic back to the previous implementation, but kept the import relative to the `static` directory instead of `static/img`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
