### PR TITLE
Center the logo

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -156,6 +156,7 @@ article .card {
     var(--ifm-color-emphasis-200);
 }
 
+/* Effectively center the logo in the navbar */
 @media (max-width: 996px) {
   .navbar__items {
     justify-content: space-between;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -156,6 +156,12 @@ article .card {
     var(--ifm-color-emphasis-200);
 }
 
+@media (max-width: 996px) {
+  .navbar__items {
+    justify-content: space-between;
+  }
+}
+
 .navbar__item {
   font-family: 'Metropolis Semi Bold';
   font-size: 0.9rem;


### PR DESCRIPTION
# Description of change

#474 will use the default navbar again, moving the menu toggle to the left on mobile. From a stylistic perspective moving the logo to the center seems visually more appropriate.

I think it is best to merge this after the beta 17 branch is merged.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
