### PR TITLE
Use mainnet branch for hornet

### DIFF
--- a/.github/workflows/EXTERNAL_DOCS_CONFIG
+++ b/.github/workflows/EXTERNAL_DOCS_CONFIG
@@ -40,6 +40,7 @@
         routeBasePath: "hornet",
         sidebarPath: require.resolve("./external/hornet/documentation/sidebars.js"),
         editUrl: 'https://github.com/gohornet/hornet/edit/mainnet',
+        breadcrumbs: false,
       }
     ],
     [

--- a/.github/workflows/EXTERNAL_DOCS_CONFIG
+++ b/.github/workflows/EXTERNAL_DOCS_CONFIG
@@ -39,7 +39,7 @@
         path: "external/hornet/documentation/docs",
         routeBasePath: "hornet",
         sidebarPath: require.resolve("./external/hornet/documentation/sidebars.js"),
-        editUrl: 'https://github.com/gohornet/hornet/edit/develop',
+        editUrl: 'https://github.com/gohornet/hornet/edit/mainnet',
       }
     ],
     [

--- a/config.json
+++ b/config.json
@@ -41,7 +41,7 @@
     },
     {
       "repo": "https://github.com/gohornet/hornet",
-      "checkoutParams": ["--branch develop"],
+      "checkoutParams": ["--branch mainnet"],
       "staticPath": "./documentation/static"
     },
     {


### PR DESCRIPTION
# Description of change

Updated hornet config to use mainnet branch as develop is used for stardust

## Type of change

- Documentation Fix

## How the change has been tested

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested the wiki locally and tested that all external links work
