### PR TITLE
Fix dropdown offset

### DIFF
--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -10,7 +10,7 @@
 .dropdown__container {
   position: absolute;
   padding-top: calc(
-    0.5 * var(--ifm-navbar-height) - 0.5rem * var(--ifm-line-height-base) -
+    0.5 * var(--ifm-navbar-height) - 0.5em * var(--ifm-line-height-base) -
       var(--ifm-navbar-item-padding-vertical) + 1px
   );
   width: 100%;
@@ -19,7 +19,7 @@
   display: none;
   z-index: var(--ifm-z-index-dropdown);
   top: calc(
-    0.5 * var(--ifm-navbar-height) + 0.5rem * var(--ifm-line-height-base) +
+    0.5 * var(--ifm-navbar-height) + 0.5em * var(--ifm-line-height-base) +
       var(--ifm-navbar-item-padding-vertical) - 1px
   );
   left: 0;

--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -10,14 +10,18 @@
 .dropdown__container {
   position: absolute;
   padding-top: calc(
-    var(--ifm-navbar-padding-vertical) + var(--ifm-global-border-width) + 5px
+    0.5 * var(--ifm-navbar-height) - 0.5rem * var(--ifm-line-height-base) -
+      var(--ifm-navbar-item-padding-vertical) + 1px
   );
   width: 100%;
   opacity: 0;
   visibility: hidden;
   display: none;
   z-index: var(--ifm-z-index-dropdown);
-  top: calc(100% - var(--ifm-navbar-padding-vertical) - 5px);
+  top: calc(
+    0.5 * var(--ifm-navbar-height) + 0.5rem * var(--ifm-line-height-base) +
+      var(--ifm-navbar-item-padding-vertical) - 1px
+  );
   left: 0;
   transition-property: opacity, visibility;
   transition-duration: var(--ifm-transition-fast);

--- a/src/theme/NavbarItem/styles.css
+++ b/src/theme/NavbarItem/styles.css
@@ -11,7 +11,7 @@
   position: absolute;
   padding-top: calc(
     0.5 * var(--ifm-navbar-height) - 0.5em * var(--ifm-line-height-base) -
-      var(--ifm-navbar-item-padding-vertical) + 1px
+      var(--ifm-navbar-item-padding-vertical) + 5px
   );
   width: 100%;
   opacity: 0;
@@ -20,7 +20,7 @@
   z-index: var(--ifm-z-index-dropdown);
   top: calc(
     0.5 * var(--ifm-navbar-height) + 0.5em * var(--ifm-line-height-base) +
-      var(--ifm-navbar-item-padding-vertical) - 1px
+      var(--ifm-navbar-item-padding-vertical) - 5px
   );
   left: 0;
   transition-property: opacity, visibility;


### PR DESCRIPTION
# Description of change

This should fix the bug reported by Aleksei. This now calculates the offsets of the mega menu relative to the center of the navbar.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Check if there are pixel gaps between the build link and the mega menu. Tested on Chrome.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
