### PR TITLE
Fix image zoom selector

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
       applicationId: '2809821',
     },
     imageZoom: {
-      selector: '.markdown :not(a) > img',
+      selector: '.markdown :not(a) > img:not(.image-gallery-image)',
       // Optional medium-zoom options
       // see: https://www.npmjs.com/package/medium-zoom#options
       options: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,8 @@ module.exports = {
       applicationId: '2809821',
     },
     imageZoom: {
-      selector: '.markdown :not(a) > img:not(.image-gallery-image)',
+      selector:
+        '.markdown :not(a) > img:not(.image-gallery-image):not(.image-gallery-thumbnail-image)',
       // Optional medium-zoom options
       // see: https://www.npmjs.com/package/medium-zoom#options
       options: {


### PR DESCRIPTION
# Description of change

The image zoom should not be applied to the sliders, which have their own full screen implementation.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
