### PR TITLE
Learn - IOTA Messages Updates

### DIFF
--- a/internal/learn/about-iota/messages.md
+++ b/internal/learn/about-iota/messages.md
@@ -8,7 +8,7 @@ description: This topic explores messages, models, and payloads that encompass t
 
 A message is an object that nodes gossip around in the network. It always references one to eight other messages, which are known as **parents**. It is stored as a vertex on the Tangle data structure maintained by the nodes.
 
-Messages can contain payloads. Some of them are core payloads that are processed by all nodes as part of the core protocol. Others are community payloads that enable the building of new functionalities on top of the Tangle. And some payloads have other nested payloads embedded inside. So, the parsing of the message is done layer by layer, to ensure embedded payloads also have a correct syntax structure.
+Messages can contain payloads. Some of them are core payloads that are processed by all nodes as part of the core protocol. Others are community payloads that build up new functionalities on top of the Tangle. And some payloads have other nested payloads embedded inside. So, the parsing of the message is done layer by layer, to ensure embedded payloads also have a correct syntax structure.
 
 ## UTXO
 
@@ -18,7 +18,7 @@ The UTXO model defines a ledger state where balances are not directly associated
 
 ![utxo-model](/img/learn/about-iota/utxo.png)
 
-So, the UTXO is a part of a larger, self-contained, and flexible message structure known as a **payload**. This approach is meant to enable a self-contained message structure defining the data of the entire transfer as a payload to be embedded into a message.
+So, the UTXO is a part of a larger, self-contained, and flexible message structure known as a **payload**. This approach is helps enable a self-contained message structure defining the data of the entire transfer as a payload to be embedded into a message.
 
 ## Message Payloads
 
@@ -29,7 +29,7 @@ A transaction payload (defined in [TIP-0020](https://github.com/lzpap/tips/blob/
 1. The Transaction Essence part, which contains the inputs, outputs, and an optional embedded payload.
 2. The Unlock Blocks, which unlocks the Transaction Essence's inputs. In case the unlock block contains a signature, it signs the entire Transaction Essence part.
 
-In general, all parts of a transaction payload begin with a byte describing the type of the given part to keep the flexibility to introduce new types or versions of the given part in the future.
+In general, all parts of a transaction payload begin with a byte describing the type of a given part. This helps keep the flexibility of introducing new types or versions of the given part in the future.
 
 And, as mentioned above, the payload part of a Transaction Essence can hold an optional payload. This payload does not affect the validity of the Transaction Essence. If the transaction is not valid, then the payload must also be discarded.
 
@@ -39,7 +39,7 @@ The concept of the payload (defined in [TIP-0023](https://github.com/Wollac/prot
 
 ### Milestone Payload
 
-A milestone payload (defined in [TIP-0029](https://github.com/iotaledger/tips/blob/milestone-with-signature-blocks/tips/TIP-0029/tip-0029.md))contains the Milestone Essence, which consists of the actual milestone information (like its index number or position in the Tangle), which is signed using the Ed25519 signature scheme. It uses keys of 32 bytes, while the generated signatures are 64 bytes.
+A milestone payload (defined in [TIP-0029](https://github.com/iotaledger/tips/blob/milestone-with-signature-blocks/tips/TIP-0029/tip-0029.md)) contains the Milestone Essence, which consists of the actual milestone information (like its index number or position in the Tangle), which is signed using the Ed25519 signature scheme. It uses keys of 32 bytes, while the generated signatures are 64 bytes.
 
 To increase the security of the design, a milestone can (optionally) be independently signed by multiple keys at once. These keys should be operated by detached signature provider services running on independent infrastructure elements. This assists in mitigating the risk of an attacker having access to all the key material necessary for forging milestones.
 

--- a/internal/learn/about-iota/messages.md
+++ b/internal/learn/about-iota/messages.md
@@ -1,19 +1,18 @@
 ---
 id: messages
 title: Messages
-description: This topic explores messages, models, and payloads that encompass
-  the transfer of data within the Tangle.
+description: This topic explores messages, models, and payloads that encompass the transfer of data within the Tangle.
 ---
 
 # Messages
 
 A message is an object that nodes gossip around in the network. It always references one to eight other messages, which are known as **parents**. It is stored as a vertex on the Tangle data structure maintained by the nodes.
 
-Messages can contain payloads. Some of them are core payloads that are processed by all nodes as part of the core protocol. Others are community payloads that enable the building of new functionalities on top of the Tangle. And some payloads have other nested payloads embedded inside. So, the parsing of the message is done layer by layer, to ensure also embedded payloads have a correct syntax structure.
+Messages can contain payloads. Some of them are core payloads that are processed by all nodes as part of the core protocol. Others are community payloads that enable the building of new functionalities on top of the Tangle. And some payloads have other nested payloads embedded inside. So, the parsing of the message is done layer by layer, to ensure embedded payloads also have a correct syntax structure.
 
 ## UTXO
 
-Previously, the IOTA protocol used transactions (which were vertices in the Tangle), where each transaction defined either an input or an output. A grouping of those input/output transaction vertices made up a bundle that transferred the given values as an atomic unit. But this approach was seen as too time-consuming. So, we adopted a new transaction structure called the **unspent transaction outputs **(UTXO).
+Previously, the IOTA protocol used transactions (which were vertices in the Tangle), where each transaction defined either an input or an output. A grouping of those input and output transaction vertices made up a bundle that transferred the given values as an atomic unit. But this approach was seen as too time-consuming. So, we adopted a new transaction structure called the **unspent transaction outputs **(UTXO)**.
 
 The UTXO model defines a ledger state where balances are not directly associated with addresses but with the outputs of transactions. In this model, transactions specify the outputs of previous transactions as inputs, which are consumed to create new outputs. A transaction must consume the entirety of the specified inputs.
 
@@ -21,48 +20,34 @@ The UTXO model defines a ledger state where balances are not directly associated
 
 So, the UTXO is a part of a larger, self-contained, and flexible message structure known as a **payload**. This approach is meant to enable a self-contained message structure defining the data of the entire transfer as a payload to be embedded into a message.
 
-Overall, these payload structures are simple:
+## Message Payloads
 
-| Name         | Type      | Description                                          |
-| ------------ | --------- | ---------------------------------------------------- |
-| Payload Type | uint32    | must be set to **2**                                 |
-| Index        | String    | The index key of the message, a UTF-8 encoded string |
-| DATA         | ByteArray | Data we are attaching                                |
+### Transaction Payload
 
-Additionally, there can be three types of message payloads:
-
-- A transaction payload
-- An indexation payload
-- A milestone payload
-
-## Message payloads
-
-### Transaction payload
-
-A transaction payload is made up of two parts:
+A transaction payload (defined in [TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md)) is made up of two parts:
 
 1. The Transaction Essence part, which contains the inputs, outputs, and an optional embedded payload.
 2. The Unlock Blocks, which unlocks the Transaction Essence's inputs. In case the unlock block contains a signature, it signs the entire Transaction Essence part.
 
-In general, all parts of a transaction payload begin with a byte describing the type of the given part to keep the flexibility to introduce new types/versions of the given part in the future.
+In general, all parts of a transaction payload begin with a byte describing the type of the given part to keep the flexibility to introduce new types or versions of the given part in the future.
 
 And, as mentioned above, the payload part of a Transaction Essence can hold an optional payload. This payload does not affect the validity of the Transaction Essence. If the transaction is not valid, then the payload must also be discarded.
 
-### Indexation payload
+### Tagged Data Payload
 
-The concept of the payload allows for the addition of an index to the encapsulating message, as well as some arbitrary data. Nodes expose an application programming interface that enables the querying of messages by the index. Index payloads may also be contained within a transaction payload.
+The concept of the payload (defined in [TIP-0023](https://github.com/Wollac/protocol-rfcs/blob/tagged-data/tips/TIP-0023/tip-0023.md)) allows for the addition of a tag to the encapsulating message, as well as some arbitrary data. Certain nodes or data indexing applications may expose an application programming interface that enables the querying of messages by the tag. Tagged data payloads may also be contained within a transaction payload.
 
-### Milestone payload
+### Milestone Payload
 
-A milestone payload contains the Milestone Essence, which consists of the actual milestone information (like its index number or position in the tangle), which is signed using the Ed25519 signature scheme. It uses keys of 32 bytes, while the generated signatures are 64 bytes.
+A milestone payload (defined in [TIP-0029](https://github.com/iotaledger/tips/blob/milestone-with-signature-blocks/tips/TIP-0029/tip-0029.md))contains the Milestone Essence, which consists of the actual milestone information (like its index number or position in the Tangle), which is signed using the Ed25519 signature scheme. It uses keys of 32 bytes, while the generated signatures are 64 bytes.
 
 To increase the security of the design, a milestone can (optionally) be independently signed by multiple keys at once. These keys should be operated by detached signature provider services running on independent infrastructure elements. This assists in mitigating the risk of an attacker having access to all the key material necessary for forging milestones.
 
-In addition, a key rotation policy can also be enforced by limiting key validity to certain milestone intervals.
+Additionally, a key rotation policy can also be enforced by limiting key validity to certain milestone intervals.
 
 ### Conflict
 
-Additionally, if messages conflict, milestones can confirm them by enforcing deterministic ordering by applying only the first message that will not violate the ledger state; this is accomplished by using the White Flag feature.
+Additionally, if messages conflict, milestones can confirm them by enforcing deterministic ordering by applying only the first message that will not violate the ledger state; this is accomplished by using the [White Flag](https://govern.iota.org/t/conflict-white-flag-mitigate-conflict-spamming-by-ignoring-conflicts/233) feature.
 
 ## Validation
 

--- a/internal/learn/about-iota/messages.md
+++ b/internal/learn/about-iota/messages.md
@@ -22,6 +22,16 @@ So, the UTXO is a part of a larger, self-contained, and flexible message structu
 
 ## Message Payloads
 
+:::note
+
+In the upcoming Stardust release, there are updates to the three message payload types and their functions:
+
+- [Transaction Payloads](#transaction-payload)
+- [Tagged Data Payloads](#tagged-data-payload)
+- [Milestone Payloads](#milestone-payload)
+
+:::
+
 ### Transaction Payload
 
 A transaction payload (defined in [TIP-0020](https://github.com/lzpap/tips/blob/tx-updates/tips/TIP-0020/tip-0020.md)) is made up of two parts:

--- a/internal/learn/about-iota/messages.md
+++ b/internal/learn/about-iota/messages.md
@@ -12,13 +12,13 @@ Messages can contain payloads. Some of them are core payloads that are processed
 
 ## UTXO
 
-Previously, the IOTA protocol used transactions (which were vertices in the Tangle), where each transaction defined either an input or an output. A grouping of those input and output transaction vertices made up a bundle that transferred the given values as an atomic unit. But this approach was seen as too time-consuming. So, we adopted a new transaction structure called the **unspent transaction outputs **(UTXO)**.
+Previously, the IOTA protocol used transactions (which were vertices in the Tangle), where each transaction defined either an input or an output. A grouping of those input and output transaction vertices made up a bundle that transferred the given values as an atomic unit. But this approach was seen as too time-consuming. So, we adopted a new transaction structure called the **unspent transaction outputs (UTXO)**.
 
 The UTXO model defines a ledger state where balances are not directly associated with addresses but with the outputs of transactions. In this model, transactions specify the outputs of previous transactions as inputs, which are consumed to create new outputs. A transaction must consume the entirety of the specified inputs.
 
 ![utxo-model](/img/learn/about-iota/utxo.png)
 
-So, the UTXO is a part of a larger, self-contained, and flexible message structure known as a **payload**. This approach is helps enable a self-contained message structure defining the data of the entire transfer as a payload to be embedded into a message.
+So, the UTXO is a part of a larger, self-contained, and flexible message structure known as a **payload**. This approach helps enable a self-contained message structure defining the data of the entire transfer as a payload to be embedded into a message.
 
 ## Message Payloads
 
@@ -29,7 +29,7 @@ A transaction payload (defined in [TIP-0020](https://github.com/lzpap/tips/blob/
 1. The Transaction Essence part, which contains the inputs, outputs, and an optional embedded payload.
 2. The Unlock Blocks, which unlocks the Transaction Essence's inputs. In case the unlock block contains a signature, it signs the entire Transaction Essence part.
 
-In general, all parts of a transaction payload begin with a byte describing the type of a given part. This helps keep the flexibility of introducing new types or versions of the given part in the future.
+In general, all parts of a transaction payload begin with a byte describing the type of a given part. This allows the introduction of new types or versions of the given part in the future.
 
 And, as mentioned above, the payload part of a Transaction Essence can hold an optional payload. This payload does not affect the validity of the Transaction Essence. If the transaction is not valid, then the payload must also be discarded.
 


### PR DESCRIPTION
# Description of change

Content in the Learn: Value Transfer section has been updated in lieu of the Stardust updates which includes:

- updating the utxo model and payloads
- removing "payloads" entirely
- Adding reference links where applicable

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix
- Documentation Enhancement

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
