### PR TITLE
Use 0.5 support branch for identity

### DIFF
--- a/.github/workflows/EXTERNAL_DOCS_CONFIG
+++ b/.github/workflows/EXTERNAL_DOCS_CONFIG
@@ -51,7 +51,7 @@
         routeBasePath: "identity.rs",
         sidebarPath: require.resolve("./external/identity.rs/documentation/sidebars.js"),
         remarkPlugins: [require("remark-code-import"), require("remark-import-partial"), require('remark-remove-comments') ],
-        editUrl: 'https://github.com/iotaledger/identity.rs/edit/dev',
+        editUrl: 'https://github.com/iotaledger/identity.rs/edit/support/v0.5',
         breadcrumbs: false,
       }
     ],

--- a/config.json
+++ b/config.json
@@ -46,6 +46,7 @@
     },
     {
       "repo": "https://github.com/iotaledger/identity.rs",
+      "checkoutParams": ["--branch support/v0.5"],
       "staticPath": "./documentation/static"
     },
     {


### PR DESCRIPTION
# Description of change

Use a support branch to pin the identity docs to the 0.5 version.

Note:
- The edit link does not resolve, but neither did the old one
- locally I get an error for the goshimmer sidebar.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Ran the build locally, I got an error from the goshimmer sidebar config the first time, but it worked the second time.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested the wiki locally and tested that all external links work
