### PR TITLE
Checkout submodules on test build too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # Needed for showLastUpdateTime to work
       - name: Init and update submodules
         run: |
-          yarn checkout:remote
+          git submodule update --init --recursive --remote
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,24 +1,12 @@
 name: deploy
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
-  checks:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Test Build
-        run: |
-          yarn install --immutable
-          yarn build
-  gh-release:
-    if: github.event_name != 'pull_request'
+  deploy:
     runs-on: ubuntu-latest
     env:
       BUILD: '*/*/documentation'
@@ -28,7 +16,7 @@ jobs:
           fetch-depth: 0 # Needed for showLastUpdateTime to work
       - name: Init and update submodules
         run: |
-          git submodule update --init --recursive --remote
+          yarn checkout:remote
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: test
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    env:
+      BUILD: '*/*/documentation'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Needed for showLastUpdateTime to work
+      - name: Init and update submodules
+        run: |
+          yarn checkout:remote
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+      - name: Add external doc config
+        run: |
+          yarn cli start
+      - name: Checkout external docs
+        run: |
+          yarn cli checkout --no-overwrite
+      - name: Build
+        run: |
+          yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  checks:
+  test:
     runs-on: ubuntu-latest
     env:
       BUILD: '*/*/documentation'
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # Needed for showLastUpdateTime to work
       - name: Init and update submodules
         run: |
-          yarn checkout:remote
+          git submodule update --init --recursive --remote
       - name: Install dependencies
         run: |
           yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "lint": "eslint --cache --fix src",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "cli": "iota-wiki-cli",
-    "checkout": "git submodule update --init --recursive",
-    "checkout:remote": "yarn checkout --remote"
+    "cli": "iota-wiki-cli"
   },
   "dependencies": {
     "@algolia/client-search": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "lint": "eslint --cache --fix src",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "cli": "iota-wiki-cli"
+    "cli": "iota-wiki-cli",
+    "checkout": "git submodule update --init --recursive",
+    "checkout:remote": "yarn checkout --remote"
   },
   "dependencies": {
     "@algolia/client-search": "^4.9.1",


### PR DESCRIPTION
# Description of change

Currently the test build fails because we are in the process of switching to submodules for external repos, which when not checked out result in a lock file mutation when installing dependencies.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The scripts are tested locally. The workflows should run in this PR and when merged.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
