### PR TITLE
Make versioning more prominent

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -31,6 +31,17 @@
   font-family: 'Metropolis Semi Bold', sans-serif;
 }
 
+.version .navbar__item,
+.version .menu__list-item {
+  border-radius: var(--ifm-global-radius);
+  background-color: var(--ifm-color-emphasis-200);
+}
+
+.version .menu__link--active,
+.version .menu__link:hover {
+  background-color: unset;
+}
+
 .card {
   min-width: 14rem;
 }

--- a/src/css/patches.css
+++ b/src/css/patches.css
@@ -46,6 +46,12 @@ hr {
 /*
 Patch to use transformed font icons in dropdowns and expanded menus
 */
+.navbar__item.dropdown,
+.dropdown .navbar__item {
+  position: relative;
+  padding-right: calc(1rem + var(--ifm-navbar-item-padding-horizontal))
+}
+
 .dropdown > .navbar__link:after {
   border: none;
   content: none;
@@ -54,6 +60,7 @@ Patch to use transformed font icons in dropdowns and expanded menus
   margin-left: auto;
   position: absolute;
   top: 0;
+  right: 1rem;
   transform: none;
 }
 

--- a/src/theme/NavbarItem/index.tsx
+++ b/src/theme/NavbarItem/index.tsx
@@ -70,5 +70,9 @@ export default function NavbarItem({ type, ...props }: Props): JSX.Element {
     (props as DropdownNavbarItemProps).items !== undefined,
   );
   const NavbarItemComponent = getNavbarItemComponent(componentType);
-  return <NavbarItemComponent {...props} />;
+  return (
+    ['docsVersion', 'docsVersionDropdown'].includes(type)
+      ? <div className='version'><NavbarItemComponent {...props} /></div>
+      : <NavbarItemComponent {...props} />
+  );
 }


### PR DESCRIPTION
# Description of change

This is a temporary fix to make versioning more prominent in the page by giving the dropdowns a different background color.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested with a local Wiki build.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
