### PR TITLE
Fix social icon alignment on mobile

### DIFF
--- a/src/components/Social/styles.css
+++ b/src/components/Social/styles.css
@@ -9,7 +9,6 @@
 
 .social__icon {
   font-size: larger;
-  margin-right: 0.5rem;
 }
 
 .social__link {
@@ -28,6 +27,7 @@
 .social__title {
   display: none;
   font-weight: 500;
+  margin-left: 0.5rem;
   color: var(--ifm-color-gray-0);
 }
 


### PR DESCRIPTION
# Description of change

The icons on mobile were off center because it got a margin to create space between the icon and title on desktop. So I moved the margin from the icon to the title and now the icons are centered on mobile.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
