### PR TITLE
fix evm link

### DIFF
--- a/content/tutorials/single-page-tutorials/docusaurus.config.js
+++ b/content/tutorials/single-page-tutorials/docusaurus.config.js
@@ -56,9 +56,9 @@ module.exports = {
             '@iota-wiki/plugin-tutorial',
             {
                 title: 'Run a EVM Chain',
-                description: 'In this tutorial you will learn how to run an EVM node.',
+                description: 'In this tutorial you will learn how to use an EVM chain.',
                 preview: 'IOTA-Smart-Contract-Tutorials-D.jpg',
-                route: 'smart-contracts/guide/evm/create-chain',
+                route: 'smart-contracts/guide/evm/using',
                 tags: ['text', 'video'],
             }
         ],


### PR DESCRIPTION
# Description of change

Fix broken link of the "Run a EVM Chain" tutorial

Old: https://wiki.iota.org/smart-contracts/guide/evm/create-chain
New: https://wiki.iota.org/smart-contracts/guide/evm/using