### PR TITLE
Test build with checked-in submodule versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
           corepack enable
       - name: Init and update submodules
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --recursive
       - name: Install dependencies
         run: |
-          yarn install --immutable
+          yarn install
       - name: Build
         run: |
           yarn build


### PR DESCRIPTION
# Description of change

The test build should use the submodule versions checked into the repo to test the current state of the repo. This avoids a disconnect between the lock file and checked-in submodule dependencies. Let the production build use the up-to-date remote versions and check if any lock file updates are needed.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
