### PR TITLE
Increase heap limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CONTENT: '*/*/*/documentation,*/*/*,*/*'
+      NODE_OPTIONS: '--max-old-space-size=3072'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CONTENT: '*/*/*/documentation,*/*/*,*/*'
+      NODE_OPTIONS: '--max-old-space-size=3072'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Description of change

Increased the heap size to 3GB. Seems to work now. Github runner used 2GB and my pc uses 4GB by default

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tried to deploy. Build was successful.
https://github.com/iota-community/iota-wiki/runs/8070097187?check_suite_focus=true

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested the wiki locally and tested that all external links work
